### PR TITLE
Back out noarch: python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,8 @@ source:
   sha256: 84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
 
 build:
-  noarch: python
-  number: 1004
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 1005
+  script: "{{ PYTHON }} -m pip install . -vvv"
   entry_points:
     - chardetect = chardet.cli.chardetect:main
 


### PR DESCRIPTION
noarch: python packages with names before `conda` are giving trouble.